### PR TITLE
Bugfix für Timer-Auswertungen

### DIFF
--- a/plugin/generic/Logikprozessor.pl
+++ b/plugin/generic/Logikprozessor.pl
@@ -931,10 +931,8 @@ for my $timer (grep /$plugname\__.*_(timer|delay|followup|cool)/, keys %plugin_i
 	my $deadtime=time()-$timebefore;
 	plugin_log("$plugname $t",sprintf("logic took %.1fs (timer)",$deadtime)) if $deadtime>0.5;
     }
-    else # noch nicht faelliger Timer
-    {
-	$nexttimer=$timer if !defined $nexttimer || $plugin_info{$timer}<$plugin_info{$nexttimer};
-    }
+
+    $nexttimer=$timer if !defined $nexttimer || $plugin_info{$timer}<$plugin_info{$nexttimer};
 }
 
 # Suche Timer-Logiken, bei denen aus irgendeinem Grund der naechste Aufruf noch nicht berechnet wurde,

--- a/plugin/generic/Logikprozessor.pl
+++ b/plugin/generic/Logikprozessor.pl
@@ -816,8 +816,7 @@ if($event=~/bus/)
 
 # Ab hier gemeinsamer Code fuer Ausfuehrung auf Bustraffic hin, sowie "zyklische" Ausfuehrung (auf Timer/Followup/Delay hin).
 
-# Evtl. faellige Timer finden, gleichzeitig Timer fuer nachste Aktion setzen
-my $nexttimer=undef;
+# Evtl. faellige Timer finden
 for my $timer (grep /$plugname\__.*_(timer|delay|followup|cool)/, keys %plugin_info) # alle Timer
 {
     my $scheduled_time=$plugin_info{$timer};
@@ -931,10 +930,15 @@ for my $timer (grep /$plugname\__.*_(timer|delay|followup|cool)/, keys %plugin_i
 	my $deadtime=time()-$timebefore;
 	plugin_log("$plugname $t",sprintf("logic took %.1fs (timer)",$deadtime)) if $deadtime>0.5;
     }
-    else # noch nicht faelliger Timer
-    {
+}
+
+# Eigener Lauf um nächsten Timer zu finden. Kann nicht mit der gleichen Schleife davor kombiniert werden, da dort bestimmte Timer noch
+# manipuliert werden.
+
+my $nexttimer=undef;
+for my $timer (grep /$plugname\__.*_(timer|delay|followup|cool)/, keys %plugin_info) # alle Timer
+{
 	$nexttimer=$timer if !defined $nexttimer || $plugin_info{$timer}<$plugin_info{$nexttimer};
-    }
 }
 
 # Suche Timer-Logiken, bei denen aus irgendeinem Grund der naechste Aufruf noch nicht berechnet wurde,


### PR DESCRIPTION
bugfix: auch der gerade aktuell ausgewertete Timer kann der "nextTimer"sein.
Daher den 'nextTimer' nicht nur im else-Zweig auswerten.

Der Bug ist bisher womöglich nicht aufgefallen, weil jeglicher für den
Logik-Prozessor relevanter Bustraffic die Timer neu berechnet. Eine
einmalig falsche Berechnung ist daher womöglich nicht aufgefallen.

In meiner Logik mit (noch) nur einem Timer kann ich auf diesen
Nebeneffekt leider nicht vertrauen.

(siehe auch Forum http://knx-user-forum.de/forum/öffentlicher-bereich/knx-eib-forum/code-schnipsel/20404-neues-plugin-logikprozessor-pl?p=842995#post842995)
